### PR TITLE
Add aliases for clean install of NPM dependencies

### DIFF
--- a/aliases.zsh
+++ b/aliases.zsh
@@ -14,6 +14,8 @@ alias dotfiles="cd $DOTFILES"
 # Development
 alias a="php artisan"
 alias cfresh="rm -rf vendor/ && composer install"
+alias nfresh="rm -rf node_modules && npm install"
+alias yfresh="rm -rf node_modules && yarn"
 alias bps="brew-php-switcher"
 
 # Docker


### PR DESCRIPTION
Remove node_modules and reinstall dependencies with NPM or Yarn.